### PR TITLE
CMC <> Mana Value

### DIFF
--- a/src/main/java/editor/collection/CardList.java
+++ b/src/main/java/editor/collection/CardList.java
@@ -81,7 +81,7 @@ public interface CardList extends Iterable<Card>
                 case NAME           -> card().unifiedName();
                 case LAYOUT         -> card().layout();
                 case MANA_COST      -> card().manaCost();
-                case CMC            -> card().cmc();
+                case MANA_VALUE            -> card().manaValue();
                 case COLORS         -> card().colors();
                 case COLOR_IDENTITY -> card().colorIdentity();
                 case TYPE_LINE      -> card().unifiedTypeLine();

--- a/src/main/java/editor/database/attributes/CardAttribute.java
+++ b/src/main/java/editor/database/attributes/CardAttribute.java
@@ -59,7 +59,7 @@ public enum CardAttribute implements Supplier<FilterLeaf<?>>, Comparator<Object>
     /** Mana cost of a card. */
     MANA_COST("Mana Cost", List.class, (a) -> new ManaCostFilter(), Comparator.comparing((a) -> CollectionUtils.convertToList(a, ManaCost.class).get(0))),
     /** Converted mana cost of a card. */
-    CMC("Mana Value", List.class, (a) -> new NumberFilter(a, Card::cmc), Comparator.comparingDouble((a) -> Collections.min(CollectionUtils.convertToList(a, Double.class)))),
+    CMC("Mana Value", Double.class, (a) -> new NumberFilter(a, (c) -> Collections.singleton(c.cmc())), (a, b) -> ((Double)a).compareTo((Double)b)),
     /** Colors of all faces of a card. */
     COLORS("Colors", List.class, (a) -> new ColorFilter(a, Card::colors), (a, b) -> {
         var first = CollectionUtils.convertToList(a, ManaType.class);

--- a/src/main/java/editor/database/attributes/CardAttribute.java
+++ b/src/main/java/editor/database/attributes/CardAttribute.java
@@ -58,8 +58,8 @@ public enum CardAttribute implements Supplier<FilterLeaf<?>>, Comparator<Object>
     PRINTED_TEXT("Printed Text", (a) -> new TextFilter(a, Card::normalizedPrinted)),
     /** Mana cost of a card. */
     MANA_COST("Mana Cost", List.class, (a) -> new ManaCostFilter(), Comparator.comparing((a) -> CollectionUtils.convertToList(a, ManaCost.class).get(0))),
-    /** Converted mana cost of a card. */
-    CMC("Mana Value", Double.class, (a) -> new NumberFilter(a, (c) -> Collections.singleton(c.cmc())), (a, b) -> ((Double)a).compareTo((Double)b)),
+    /** Mana value cost of a card. */
+    MANA_VALUE("Mana Value", Double.class, (a) -> new NumberFilter(a, (c) -> Collections.singleton(c.manaValue())), (a, b) -> ((Double)a).compareTo((Double)b)),
     /** Colors of all faces of a card. */
     COLORS("Colors", List.class, (a) -> new ColorFilter(a, Card::colors), (a, b) -> {
         var first = CollectionUtils.convertToList(a, ManaType.class);

--- a/src/main/java/editor/database/attributes/CardAttribute.java
+++ b/src/main/java/editor/database/attributes/CardAttribute.java
@@ -59,7 +59,7 @@ public enum CardAttribute implements Supplier<FilterLeaf<?>>, Comparator<Object>
     /** Mana cost of a card. */
     MANA_COST("Mana Cost", List.class, (a) -> new ManaCostFilter(), Comparator.comparing((a) -> CollectionUtils.convertToList(a, ManaCost.class).get(0))),
     /** Converted mana cost of a card. */
-    CMC("CMC", List.class, (a) -> new NumberFilter(a, Card::cmc), Comparator.comparingDouble((a) -> Collections.min(CollectionUtils.convertToList(a, Double.class)))),
+    CMC("Mana Value", List.class, (a) -> new NumberFilter(a, Card::cmc), Comparator.comparingDouble((a) -> Collections.min(CollectionUtils.convertToList(a, Double.class)))),
     /** Colors of all faces of a card. */
     COLORS("Colors", List.class, (a) -> new ColorFilter(a, Card::colors), (a, b) -> {
         var first = CollectionUtils.convertToList(a, ManaType.class);

--- a/src/main/java/editor/database/attributes/CardAttribute.java
+++ b/src/main/java/editor/database/attributes/CardAttribute.java
@@ -179,6 +179,11 @@ public enum CardAttribute implements Supplier<FilterLeaf<?>>, Comparator<Object>
         for (CardAttribute c : CardAttribute.values())
             if (c.toString().equalsIgnoreCase(s))
                 return c;
+        // Mana value special case for old converted mana cost terminology
+        // (since this is the only case of this so far, it's not worth creating
+        // a new field for it)
+        if (s.equalsIgnoreCase("cmc"))
+            return MANA_VALUE;
         throw new IllegalArgumentException("Unknown attribute \"" + s + "\"");
     }
 

--- a/src/main/java/editor/database/attributes/CardAttribute.java
+++ b/src/main/java/editor/database/attributes/CardAttribute.java
@@ -58,8 +58,12 @@ public enum CardAttribute implements Supplier<FilterLeaf<?>>, Comparator<Object>
     PRINTED_TEXT("Printed Text", (a) -> new TextFilter(a, Card::normalizedPrinted)),
     /** Mana cost of a card. */
     MANA_COST("Mana Cost", List.class, (a) -> new ManaCostFilter(), Comparator.comparing((a) -> CollectionUtils.convertToList(a, ManaCost.class).get(0))),
-    /** Mana value cost of a card. */
+    /** Mana value of a card. */
     MANA_VALUE("Mana Value", Double.class, (a) -> new NumberFilter(a, (c) -> Collections.singleton(c.manaValue())), (a, b) -> ((Double)a).compareTo((Double)b)),
+    /** Smallest mana value of a card. */
+    MIN_VALUE("Min Mana Value", Double.class, (a) -> new NumberFilter(a, (c) -> Collections.singleton(c.minManaValue())), (a, b) -> ((Double)a).compareTo((Double)b)),
+    /** Largest mana value of a card. */
+    MAX_VALUE("Max Mana Value", Double.class, (a) -> new NumberFilter(a, (c) -> Collections.singleton(c.maxManaValue())), (a, b) -> ((Double)a).compareTo((Double)b)),
     /** Colors of all faces of a card. */
     COLORS("Colors", List.class, (a) -> new ColorFilter(a, Card::colors), (a, b) -> {
         var first = CollectionUtils.convertToList(a, ManaType.class);

--- a/src/main/java/editor/database/attributes/ManaCost.java
+++ b/src/main/java/editor/database/attributes/ManaCost.java
@@ -20,7 +20,7 @@ import editor.util.Containment;
 
 /**
  * This class represents a mana cost.  It contains a list of Symbols, which may contain duplicate elements.
- * It also calculates its converted mana cost based on the number and types of Symbols it contains, and
+ * It also calculates its mana value cost based on the number and types of Symbols it contains, and
  * can determine if it is a super- or subset of another mana cost.
  *
  * @author Alec Roelke
@@ -112,7 +112,7 @@ public class ManaCost extends AbstractList<ManaSymbol> implements Comparable<Man
     }
 
     /**
-     * @return Converted mana cost of this ManaCost, which is the total value of its Symbols.
+     * @return Mana value cost of this ManaCost, which is the total value of its Symbols.
      */
     public double cmc()
     {
@@ -239,7 +239,7 @@ public class ManaCost extends AbstractList<ManaSymbol> implements Comparable<Man
 
     /**
      * @param o ManaCost to compare with
-     * @return A negative number if this ManaCost's converted mana cost is less than
+     * @return A negative number if this ManaCost's mana value is less than
      * the other or if its color intensity is less, 0 if they are the same, and a positive number
      * if they are greater.
      */

--- a/src/main/java/editor/database/attributes/ManaCost.java
+++ b/src/main/java/editor/database/attributes/ManaCost.java
@@ -252,9 +252,9 @@ public class ManaCost extends AbstractList<ManaSymbol> implements Comparable<Man
             return 1;
         else
         {
-            // Start by sorting by CMC
+            // Start by sorting by mana value
             int diff = (int)(2 * (manaValue() - o.manaValue()));
-            // If the two costs have the same CMC, sort them by symbol color intensity
+            // If the two costs have the same mana value, sort them by symbol color intensity
             if (diff == 0)
             {
                 var intensityList = intensity.values().stream().sorted().collect(Collectors.toList());

--- a/src/main/java/editor/database/attributes/ManaCost.java
+++ b/src/main/java/editor/database/attributes/ManaCost.java
@@ -114,7 +114,7 @@ public class ManaCost extends AbstractList<ManaSymbol> implements Comparable<Man
     /**
      * @return Mana value cost of this ManaCost, which is the total value of its Symbols.
      */
-    public double cmc()
+    public double manaValue()
     {
         return cost.stream().mapToDouble(ManaSymbol::value).sum();
     }
@@ -253,7 +253,7 @@ public class ManaCost extends AbstractList<ManaSymbol> implements Comparable<Man
         else
         {
             // Start by sorting by CMC
-            int diff = (int)(2 * (cmc() - o.cmc()));
+            int diff = (int)(2 * (manaValue() - o.manaValue()));
             // If the two costs have the same CMC, sort them by symbol color intensity
             if (diff == 0)
             {

--- a/src/main/java/editor/database/card/Card.java
+++ b/src/main/java/editor/database/card/Card.java
@@ -190,6 +190,18 @@ public abstract class Card
     public abstract double manaValue();
 
     /**
+     * @return this card's smallest mana value (if it has only one face, this will be the same
+     * as its mana value).
+     */
+    public abstract double minManaValue();
+
+    /**
+     * @return this card's largest mana value (if it has only one face, this will be the same
+     * as its mana value).
+     */
+    public abstract double maxManaValue();
+
+    /**
      * Get this Card's color identity, which is comprised of its its colors and colors of any
      * mana symbols that appear in its rules text that is not reminder text, and in abilities that
      * are given it by basic land types.

--- a/src/main/java/editor/database/card/Card.java
+++ b/src/main/java/editor/database/card/Card.java
@@ -202,6 +202,12 @@ public abstract class Card
     public abstract double maxManaValue();
 
     /**
+     * @return the average of this card's faces' mana values (if it has only one face, this will
+     * be the same as its mana value).
+     */
+    public abstract double avgManaValue();
+
+    /**
      * Get this Card's color identity, which is comprised of its its colors and colors of any
      * mana symbols that appear in its rules text that is not reminder text, and in abilities that
      * are given it by basic land types.

--- a/src/main/java/editor/database/card/Card.java
+++ b/src/main/java/editor/database/card/Card.java
@@ -185,11 +185,9 @@ public abstract class Card
     public abstract List<String> artist();
 
     /**
-     * Get this card's converted mana cost.
-     *
-     * @return the converted mana cost of this Card.
+     * @return this card's mana value (formerly converted mana cost).
      */
-    public abstract double cmc();
+    public abstract double manaValue();
 
     /**
      * Get this Card's color identity, which is comprised of its its colors and colors of any

--- a/src/main/java/editor/database/card/Card.java
+++ b/src/main/java/editor/database/card/Card.java
@@ -185,11 +185,11 @@ public abstract class Card
     public abstract List<String> artist();
 
     /**
-     * Get this card's converted mana cost(s).
+     * Get this card's converted mana cost.
      *
-     * @return a list containing the converted mana costs of the faces of this Card.
+     * @return the converted mana cost of this Card.
      */
-    public abstract List<Double> cmc();
+    public abstract double cmc();
 
     /**
      * Get this Card's color identity, which is comprised of its its colors and colors of any

--- a/src/main/java/editor/database/card/CardFormat.java
+++ b/src/main/java/editor/database/card/CardFormat.java
@@ -119,7 +119,7 @@ public class CardFormat
             pattern = pattern.replace(replacement, switch (type) {
                 case MANA_COST, POWER, TOUGHNESS, LOYALTY -> String.join(Card.FACE_SEPARATOR,
                     ((List<?>)card.get(type)).stream().map(String::valueOf).collect(Collectors.toList()));
-                case CMC -> String.join(Card.FACE_SEPARATOR,
+                case MANA_VALUE -> String.join(Card.FACE_SEPARATOR,
                     CollectionUtils.convertToList(card.get(type), Double.class).stream().map((n) -> {
                         if (n == n.intValue())
                             return Integer.toString(n.intValue());

--- a/src/main/java/editor/database/card/FlipCard.java
+++ b/src/main/java/editor/database/card/FlipCard.java
@@ -14,11 +14,6 @@ import editor.util.Lazy;
 public class FlipCard extends MultiCard
 {
     /**
-     * List containing the converted mana cost of each side of this FlipCard (which should just be two
-     * copies of the same value).
-     */
-    private Lazy<List<Double>> cmc;
-    /**
      * Tuple containing the mana cost of each side of this FlipCard (which should just be two copies
      * of the same value).
      */
@@ -43,7 +38,6 @@ public class FlipCard extends MultiCard
             throw new IllegalArgumentException("can't join non-flip cards into flip cards");
 
         manaCost = new Lazy<>(() -> collect(Card::manaCost));
-        cmc = new Lazy<>(() -> collect(Card::cmc));
     }
 
     /**
@@ -51,9 +45,9 @@ public class FlipCard extends MultiCard
      * Both faces of a FlipCard have the same converted mana cost.
      */
     @Override
-    public List<Double> cmc()
+    public double cmc()
     {
-        return cmc.get();
+        return top.cmc();
     }
 
     /**

--- a/src/main/java/editor/database/card/FlipCard.java
+++ b/src/main/java/editor/database/card/FlipCard.java
@@ -42,12 +42,12 @@ public class FlipCard extends MultiCard
 
     /**
      * {@inheritDoc}
-     * Both faces of a FlipCard have the same converted mana cost.
+     * The mana value of a flip card is that of its top half.
      */
     @Override
-    public double cmc()
+    public double manaValue()
     {
-        return top.cmc();
+        return top.manaValue();
     }
 
     /**

--- a/src/main/java/editor/database/card/MeldCard.java
+++ b/src/main/java/editor/database/card/MeldCard.java
@@ -20,10 +20,6 @@ import editor.util.Lazy;
 public class MeldCard extends MultiCard
 {
     /**
-     * Converted mana costs of this MeldCard's faces.
-     */
-    private Lazy<List<Double>> cmc;
-    /**
      * Front face of this MeldCard.
      */
     private final Card front;
@@ -54,7 +50,6 @@ public class MeldCard extends MultiCard
             throw new IllegalArgumentException("can't join non-meld cards into meld cards");
 
         manaCost = new Lazy<>(() -> List.of(front.manaCost().get(0), new ManaCost()));
-        cmc = new Lazy<>(() -> List.of(front.cmc().get(0), front.cmc().get(0) + other.cmc().get(0)));
     }
 
     /**
@@ -63,9 +58,9 @@ public class MeldCard extends MultiCard
      * is the sum of those of its two front faces.
      */
     @Override
-    public List<Double> cmc()
+    public double cmc()
     {
-        return cmc.get();
+        return front.cmc();
     }
 
     /**

--- a/src/main/java/editor/database/card/MeldCard.java
+++ b/src/main/java/editor/database/card/MeldCard.java
@@ -54,13 +54,13 @@ public class MeldCard extends MultiCard
 
     /**
      * {@inheritDoc}
-     * While only the front face has a mana cost, the back face's converted mana cost
-     * is the sum of those of its two front faces.
+     * The mana value of a meld card is that of its front face (after melding it's the
+     * sum of the two faces).
      */
     @Override
-    public double cmc()
+    public double manaValue()
     {
-        return front.cmc();
+        return front.manaValue();
     }
 
     /**
@@ -87,8 +87,8 @@ public class MeldCard extends MultiCard
 
     /**
      * {@inheritDoc}
-     * The back face of a MeldCard has no mana cost (but does have a converted mana cost,
-     * see {@link MeldCard#cmc()}).
+     * The back face of a MeldCard has no mana cost (but does have a mana value,
+     * see {@link MeldCard#manaValue()}).
      */
     @Override
     public List<ManaCost> manaCost()

--- a/src/main/java/editor/database/card/ModalCard.java
+++ b/src/main/java/editor/database/card/ModalCard.java
@@ -27,4 +27,13 @@ public class ModalCard extends MultiCard
         if (front.layout() != CardLayout.MODAL_DFC || b.layout() != CardLayout.MODAL_DFC)
             throw new IllegalArgumentException("can't join non-modal-double-faced cards into modal double-faced cards");
     }
+
+    /**
+     * {@inheritDoc}
+     * The mana value of a modal card is that of the front face.
+     */
+    public double cmc()
+    {
+        return front.cmc();
+    }
 }

--- a/src/main/java/editor/database/card/ModalCard.java
+++ b/src/main/java/editor/database/card/ModalCard.java
@@ -30,10 +30,11 @@ public class ModalCard extends MultiCard
 
     /**
      * {@inheritDoc}
-     * The mana value of a modal card is that of the front face.
+     * The mana value of a modal card is that of the front face (until you cast it or it enters the battlefield,
+     * at which point it becomes that of the side facing up).
      */
-    public double cmc()
+    public double manaValue()
     {
-        return front.cmc();
+        return front.manaValue();
     }
 }

--- a/src/main/java/editor/database/card/MultiCard.java
+++ b/src/main/java/editor/database/card/MultiCard.java
@@ -291,6 +291,18 @@ public abstract class MultiCard extends Card
     }
 
     @Override
+    public double minManaValue()
+    {
+        return faces.stream().mapToDouble(Card::manaValue).min().orElseThrow(() -> new IllegalStateException("multi card with no faces"));
+    }
+
+    @Override
+    public double maxManaValue()
+    {
+        return faces.stream().mapToDouble(Card::manaValue).max().orElseThrow(() -> new IllegalStateException("multi card with no faces"));
+    }
+
+    @Override
     public List<Integer> multiverseid()
     {
         return multiverseid.get();

--- a/src/main/java/editor/database/card/MultiCard.java
+++ b/src/main/java/editor/database/card/MultiCard.java
@@ -39,10 +39,6 @@ public abstract class MultiCard extends Card
      */
     private Lazy<List<String>> artist;
     /**
-     * List of converted mana costs of the faces of this MultiCard.
-     */
-    private Lazy<List<Double>> cmc;
-    /**
      * Tuple of the color identity of this MultiCard.
      */
     private Lazy<List<ManaType>> colorIdentity;
@@ -164,7 +160,6 @@ public abstract class MultiCard extends Card
 
         name = new Lazy<>(() -> collect(Card::name));
         manaCost = new Lazy<>(() -> collect(Card::manaCost));
-        cmc = new Lazy<>(() -> collect(Card::cmc));
         colors = new Lazy<>(() -> {
             var sorted = new ArrayList<>(faces.stream().flatMap((c) -> c.colors().stream()).collect(Collectors.toSet()));
             ManaType.sort(sorted);
@@ -222,12 +217,6 @@ public abstract class MultiCard extends Card
     public List<String> artist()
     {
         return artist.get();
-    }
-
-    @Override
-    public List<Double> cmc()
-    {
-        return cmc.get();
     }
 
     /**

--- a/src/main/java/editor/database/card/MultiCard.java
+++ b/src/main/java/editor/database/card/MultiCard.java
@@ -303,6 +303,12 @@ public abstract class MultiCard extends Card
     }
 
     @Override
+    public double avgManaValue()
+    {
+        return faces.stream().mapToDouble(Card::manaValue).average().orElseThrow(() -> new IllegalStateException("multi card with no faces"));
+    }
+
+    @Override
     public List<Integer> multiverseid()
     {
         return multiverseid.get();

--- a/src/main/java/editor/database/card/MultiCard.java
+++ b/src/main/java/editor/database/card/MultiCard.java
@@ -12,6 +12,9 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.swing.text.Style;
+import javax.swing.text.StyledDocument;
+
 import editor.database.attributes.CombatStat;
 import editor.database.attributes.Legality;
 import editor.database.attributes.Loyalty;
@@ -386,5 +389,30 @@ public abstract class MultiCard extends Card
     public Set<String> types()
     {
         return types.get();
+    }
+
+    @Override
+    public void formatDocument(StyledDocument document, boolean printed)
+    {
+        Style textStyle = document.getStyle("text");
+        try
+        {
+            for (int f = 0; f < faces.size(); f++)
+            {
+                formatDocument(document, printed, f);
+                if (f < faces.size() - 1)
+                    document.insertString(document.getLength(), "\n" + TEXT_SEPARATOR + "\n", textStyle);
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void formatDocument(StyledDocument document, boolean printed, int f)
+    {
+        faces.get(f).formatDocument(document, printed);
     }
 }

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -255,7 +255,7 @@ public class SingleCard extends Card
     }
 
     @Override
-    public double cmc()
+    public double manaValue()
     {
         return mana.cmc();
     }

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -255,9 +255,9 @@ public class SingleCard extends Card
     }
 
     @Override
-    public List<Double> cmc()
+    public double cmc()
     {
-        return Collections.singletonList(mana.cmc());
+        return mana.cmc();
     }
 
     @Override

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -261,6 +261,18 @@ public class SingleCard extends Card
     }
 
     @Override
+    public double minManaValue()
+    {
+        return manaValue();
+    }
+
+    @Override
+    public double maxManaValue()
+    {
+        return manaValue();
+    }
+
+    @Override
     public List<ManaType> colorIdentity()
     {
         return colorIdentity;

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -257,7 +257,7 @@ public class SingleCard extends Card
     @Override
     public double manaValue()
     {
-        return mana.cmc();
+        return mana.manaValue();
     }
 
     @Override
@@ -451,10 +451,10 @@ public class SingleCard extends Card
                 }
                 document.insertString(document.getLength(), " ", textStyle);
             }
-            if (mana.cmc() == (int)mana.cmc())
-                document.insertString(document.getLength(), "(" + (int)mana.cmc() + ")\n", textStyle);
+            if (mana.manaValue() == (int)mana.manaValue())
+                document.insertString(document.getLength(), "(" + (int)mana.manaValue() + ")\n", textStyle);
             else
-                document.insertString(document.getLength(), "(" + mana.cmc() + ")\n", textStyle);
+                document.insertString(document.getLength(), "(" + mana.manaValue() + ")\n", textStyle);
             if (!mana.colors().equals(colors))
             {
                 for (ManaType color : colors)

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -273,6 +273,12 @@ public class SingleCard extends Card
     }
 
     @Override
+    public double avgManaValue()
+    {
+        return manaValue();
+    }
+
+    @Override
     public List<ManaType> colorIdentity()
     {
         return colorIdentity;

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -8,6 +8,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Style;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+
 import editor.database.attributes.CombatStat;
 import editor.database.attributes.Expansion;
 import editor.database.attributes.Legality;
@@ -15,6 +20,9 @@ import editor.database.attributes.Loyalty;
 import editor.database.attributes.ManaCost;
 import editor.database.attributes.ManaType;
 import editor.database.attributes.Rarity;
+import editor.database.symbol.FunctionalSymbol;
+import editor.database.symbol.Symbol;
+import editor.gui.generic.ComponentUtils;
 import editor.util.UnicodeSymbols;
 
 /**
@@ -409,5 +417,175 @@ public class SingleCard extends Card
     public Set<String> types()
     {
         return types;
+    }
+
+    @Override
+    public void formatDocument(StyledDocument document, boolean printed)
+    {
+        Style textStyle = document.getStyle("text");
+        Style reminderStyle = document.getStyle("reminder");
+        Style chaosStyle = document.addStyle("CHAOS", null);
+        StyleConstants.setIcon(chaosStyle, FunctionalSymbol.CHAOS.getIcon(ComponentUtils.TEXT_SIZE));
+        try
+        {
+            document.insertString(document.getLength(), name + " ", textStyle);
+            if (!mana.isEmpty())
+            {
+                for (Symbol symbol : mana)
+                {
+                    Style style = document.addStyle(symbol.toString(), null);
+                    StyleConstants.setIcon(style, symbol.getIcon(ComponentUtils.TEXT_SIZE));
+                    document.insertString(document.getLength(), symbol.toString(), style);
+                }
+                document.insertString(document.getLength(), " ", textStyle);
+            }
+            if (mana.cmc() == (int)mana.cmc())
+                document.insertString(document.getLength(), "(" + (int)mana.cmc() + ")\n", textStyle);
+            else
+                document.insertString(document.getLength(), "(" + mana.cmc() + ")\n", textStyle);
+            if (!mana.colors().equals(colors))
+            {
+                for (ManaType color : colors)
+                {
+                    Style indicatorStyle = document.addStyle("indicator", document.getStyle("text"));
+                    StyleConstants.setForeground(indicatorStyle, color.color);
+                    document.insertString(document.getLength(), String.valueOf(UnicodeSymbols.BULLET), indicatorStyle);
+                }
+                if (!colors().isEmpty())
+                    document.insertString(document.getLength(), " ", textStyle);
+            }
+            if (printed)
+                document.insertString(document.getLength(), printedTypes + '\n', textStyle);
+            else
+                document.insertString(document.getLength(), typeLine + '\n', textStyle);
+            document.insertString(document.getLength(), expansion().name + ' ' + rarity() + '\n', textStyle);
+
+            String abilities = printed ? this.printed : text;
+            if (!abilities.isEmpty())
+            {
+                int start = 0;
+                Style style = textStyle;
+                for (int i = 0; i < abilities.length(); i++)
+                {
+                    if (i == 0 || abilities.charAt(i) == '\n')
+                    {
+                        int nextLine = abilities.substring(i + 1).indexOf('\n');
+                        int dash = (nextLine > -1 ? abilities.substring(i, nextLine + i) : abilities.substring(i)).indexOf(UnicodeSymbols.EM_DASH);
+                        if (dash > -1)
+                        {
+                            dash += i;
+                            if (i > 0)
+                                document.insertString(document.getLength(), abilities.substring(start, i), style);
+                            start = i;
+                            // Assume that the dash used for ability words is surrounded by spaces, but not
+                            // for keywords with cost parameters when the cost is nonmana cost
+                            if (abilities.charAt(dash - 1) == ' ' && abilities.charAt(dash + 1) == ' ')
+                                style = reminderStyle;
+                        }
+                    }
+                    switch (abilities.charAt(i))
+                    {
+                    case '{':
+                        document.insertString(document.getLength(), abilities.substring(start, i), style);
+                        start = i + 1;
+                        break;
+                    case '}':
+                        var symbol = Symbol.tryParseSymbol(abilities.substring(start, i));
+                        if (symbol.isEmpty())
+                        {
+                            System.err.println("Unexpected symbol {" + abilities.substring(start, i) + "} in oracle text for " + unifiedName() + ".");
+                            document.insertString(document.getLength(), abilities.substring(start, i), textStyle);
+                        }
+                        else
+                        {
+                            Style symbolStyle = document.addStyle(symbol.get().toString(), null);
+                            StyleConstants.setIcon(symbolStyle, symbol.get().getIcon(ComponentUtils.TEXT_SIZE));
+                            document.insertString(document.getLength(), symbol.get().toString(), symbolStyle);
+                        }
+                        start = i + 1;
+                        break;
+                    case '(':
+                        document.insertString(document.getLength(), abilities.substring(start, i), style);
+                        style = reminderStyle;
+                        start = i;
+                        break;
+                    case ')':
+                        document.insertString(document.getLength(), abilities.substring(start, i + 1), style);
+                        style = textStyle;
+                        start = i + 1;
+                        break;
+                    case 'C':
+                        if (i < abilities.length() - 5 && abilities.substring(i, i + 5).equals("CHAOS"))
+                        {
+                            document.insertString(document.getLength(), abilities.substring(start, i), style);
+                            document.insertString(document.getLength(), "CHAOS", chaosStyle);
+                            start = i += 5;
+                        }
+                        break;
+                    case UnicodeSymbols.EM_DASH:
+                        document.insertString(document.getLength(), abilities.substring(start, i), style);
+                        style = textStyle;
+                        start = i;
+                        break;
+                    default:
+                        break;
+                    }
+                    if (i == abilities.length() - 1 && abilities.charAt(i) != '}' && abilities.charAt(i) != ')')
+                        document.insertString(document.getLength(), abilities.substring(start, i + 1), style);
+                }
+                document.insertString(document.getLength(), "\n", textStyle);
+            }
+            if (!flavor.isEmpty())
+            {
+                int start = 0;
+                for (int i = 0; i < flavor.length(); i++)
+                {
+                    switch (flavor.charAt(i))
+                    {
+                    case '{':
+                        document.insertString(document.getLength(), flavor.substring(start, i), reminderStyle);
+                        start = i + 1;
+                        break;
+                    case '}':
+                        var symbol = Symbol.tryParseSymbol(flavor.substring(start, i));
+                        if (symbol.isEmpty())
+                        {
+                            System.err.println("Unexpected symbol {" + flavor.substring(start, i) + "} in flavor text for " + unifiedName() + ".");
+                            document.insertString(document.getLength(), flavor.substring(start, i), reminderStyle);
+                        }
+                        else
+                        {
+                            Style symbolStyle = document.addStyle(symbol.get().toString(), null);
+                            StyleConstants.setIcon(symbolStyle, symbol.get().getIcon(ComponentUtils.TEXT_SIZE));
+                            document.insertString(document.getLength(), " ", symbolStyle);
+                        }
+                        start = i + 1;
+                        break;
+                    default:
+                        break;
+                    }
+                    if (i == flavor.length() - 1 && flavor.charAt(i) != '}')
+                        document.insertString(document.getLength(), flavor.substring(start, i + 1), reminderStyle);
+                }
+                document.insertString(document.getLength(), "\n", reminderStyle);
+            }
+
+            if (power.exists() && toughness.exists())
+                document.insertString(document.getLength(), power + "/" + toughness + "\n", textStyle);
+            else if (loyalty.exists())
+                document.insertString(document.getLength(), loyalty + "\n", textStyle);
+
+            document.insertString(document.getLength(), artist + " " + number + "/" + expansion().count, textStyle);
+        }
+        catch (BadLocationException e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void formatDocument(StyledDocument document, boolean printed, int face)
+    {
+        formatDocument(document, printed);
     }
 }

--- a/src/main/java/editor/database/card/SplitCard.java
+++ b/src/main/java/editor/database/card/SplitCard.java
@@ -18,7 +18,7 @@ import editor.util.Lazy;
 public class SplitCard extends MultiCard
 {
     /**
-     * Converted mana costs of this SplitCard's faces.
+     * Mana value of this SplitCard.
      */
     private Lazy<Double> cmc;
 
@@ -48,16 +48,15 @@ public class SplitCard extends MultiCard
             if (face.layout() != f.get(0).layout())
                 throw new IllegalArgumentException("all faces of a split card must be of the same type");
 
-        cmc = new Lazy<>(() -> f.stream().mapToDouble((c) -> c.cmc()).sum());
+        cmc = new Lazy<>(() -> f.stream().mapToDouble((c) -> c.manaValue()).sum());
     }
 
     /**
      * {@inheritDoc}
-     * The converted mana cost of a split card is the sum of the converted mana costs of all
-     * of its faces.
+     * The mana value of a split card is the sum of those of all of its faces.
      */
     @Override
-    public double cmc()
+    public double manaValue()
     {
         return cmc.get();
     }

--- a/src/main/java/editor/database/card/SplitCard.java
+++ b/src/main/java/editor/database/card/SplitCard.java
@@ -20,7 +20,7 @@ public class SplitCard extends MultiCard
     /**
      * Mana value of this SplitCard.
      */
-    private Lazy<Double> cmc;
+    private Lazy<Double> manaValue;
 
     /**
      * Create a new SplitCard with the given Cards as faces.
@@ -48,7 +48,7 @@ public class SplitCard extends MultiCard
             if (face.layout() != f.get(0).layout())
                 throw new IllegalArgumentException("all faces of a split card must be of the same type");
 
-        cmc = new Lazy<>(() -> f.stream().mapToDouble((c) -> c.manaValue()).sum());
+        manaValue = new Lazy<>(() -> f.stream().mapToDouble((c) -> c.manaValue()).sum());
     }
 
     /**
@@ -58,7 +58,7 @@ public class SplitCard extends MultiCard
     @Override
     public double manaValue()
     {
-        return cmc.get();
+        return manaValue.get();
     }
 
     /**

--- a/src/main/java/editor/database/card/SplitCard.java
+++ b/src/main/java/editor/database/card/SplitCard.java
@@ -20,7 +20,7 @@ public class SplitCard extends MultiCard
     /**
      * Converted mana costs of this SplitCard's faces.
      */
-    private Lazy<List<Double>> cmc;
+    private Lazy<Double> cmc;
 
     /**
      * Create a new SplitCard with the given Cards as faces.
@@ -48,7 +48,7 @@ public class SplitCard extends MultiCard
             if (face.layout() != f.get(0).layout())
                 throw new IllegalArgumentException("all faces of a split card must be of the same type");
 
-        cmc = new Lazy<>(() -> Collections.unmodifiableList(Collections.nCopies(f.size(), f.stream().mapToDouble((c) -> c.cmc().get(0)).sum())));
+        cmc = new Lazy<>(() -> f.stream().mapToDouble((c) -> c.cmc()).sum());
     }
 
     /**
@@ -57,7 +57,7 @@ public class SplitCard extends MultiCard
      * of its faces.
      */
     @Override
-    public List<Double> cmc()
+    public double cmc()
     {
         return cmc.get();
     }

--- a/src/main/java/editor/database/card/TransformCard.java
+++ b/src/main/java/editor/database/card/TransformCard.java
@@ -44,9 +44,9 @@ public class TransformCard extends MultiCard
      * A transform card's mana value is that of its front face.
      */
     @Override
-    public double cmc()
+    public double manaValue()
     {
-        return front.cmc();
+        return front.manaValue();
     }
 
     /**

--- a/src/main/java/editor/database/card/TransformCard.java
+++ b/src/main/java/editor/database/card/TransformCard.java
@@ -14,10 +14,6 @@ import editor.util.Lazy;
 public class TransformCard extends MultiCard
 {
     /**
-     * Converted mana costs of this DoubleFacedCard's faces.
-     */
-    private Lazy<List<Double>> cmc;
-    /**
      * Card representing the front face.
      */
     private final Card front;
@@ -41,18 +37,16 @@ public class TransformCard extends MultiCard
             throw new IllegalArgumentException("can't join non-double-faced cards into double-faced cards");
 
         manaCost = new Lazy<>(() -> List.of(front.manaCost().get(0), new ManaCost()));
-        cmc = new Lazy<>(() -> List.of(front.cmc().get(0), front.cmc().get(0)));
     }
 
     /**
      * {@inheritDoc}
-     * While only the front face has a mana cost (see {@link TransformCard#manaCost()},
-     * both faces have the same converted mana cost.
+     * A transform card's mana value is that of its front face.
      */
     @Override
-    public List<Double> cmc()
+    public double cmc()
     {
-        return cmc.get();
+        return front.cmc();
     }
 
     /**

--- a/src/main/java/editor/database/symbol/ManaSymbol.java
+++ b/src/main/java/editor/database/symbol/ManaSymbol.java
@@ -102,7 +102,7 @@ public abstract class ManaSymbol extends Symbol implements Comparable<ManaSymbol
     {}
 
     /**
-     * How much this ManaSymbols is worth for calculating converted mana costs.
+     * How much this ManaSymbols is worth for calculating mana value.
      */
     private final double value;
 

--- a/src/main/java/editor/gui/display/CardTable.java
+++ b/src/main/java/editor/gui/display/CardTable.java
@@ -39,7 +39,7 @@ public class CardTable extends JTable
      * Set of CardAttribute that should not use toString to convert non-comparable data.
      */
     private static final Set<CardAttribute> NO_STRING = Set.of(CardAttribute.MANA_COST,
-                                                               CardAttribute.CMC,
+                                                               CardAttribute.MANA_VALUE,
                                                                CardAttribute.COLORS,
                                                                CardAttribute.COLOR_IDENTITY,
                                                                CardAttribute.POWER,

--- a/src/main/java/editor/gui/display/CardTableCellRenderer.java
+++ b/src/main/java/editor/gui/display/CardTableCellRenderer.java
@@ -58,7 +58,7 @@ public class CardTableCellRenderer extends DefaultTableCellRenderer
      * Several types of data get special renderings:
      * <ul>
      * <li>Mana costs are displayed using their symbols
-     * <li>Converted mana costs and combat stats are displayed using special delimiters
+     * <li>Mana values and combat stats are displayed using special delimiters
      * <li>Colors and color identity are displayed using the mana symbols corresponding to the colors
      * <li>Deck categories are displayed using colored squares
      * <li>Date added is displayed according to {@link Deck#DATE_FORMATTER}
@@ -93,7 +93,7 @@ public class CardTableCellRenderer extends DefaultTableCellRenderer
                     }
                 }
                 break;
-            case CMC:
+            case MANA_VALUE:
                 double cmc = value == null ? 0 : (Double)value;
                 panel.add(new JLabel(cmc == (int)cmc ? Integer.toString((int)cmc) : Double.toString(cmc)));
                 break;

--- a/src/main/java/editor/gui/display/CardTableCellRenderer.java
+++ b/src/main/java/editor/gui/display/CardTableCellRenderer.java
@@ -94,8 +94,8 @@ public class CardTableCellRenderer extends DefaultTableCellRenderer
                 }
                 break;
             case MANA_VALUE:
-                double cmc = value == null ? 0 : (Double)value;
-                panel.add(new JLabel(cmc == (int)cmc ? Integer.toString((int)cmc) : Double.toString(cmc)));
+                double manaValue = value == null ? 0 : (Double)value;
+                panel.add(new JLabel(manaValue == (int)manaValue ? Integer.toString((int)manaValue) : Double.toString(manaValue)));
                 break;
             case COLORS:
             case COLOR_IDENTITY:

--- a/src/main/java/editor/gui/display/CardTableCellRenderer.java
+++ b/src/main/java/editor/gui/display/CardTableCellRenderer.java
@@ -94,7 +94,8 @@ public class CardTableCellRenderer extends DefaultTableCellRenderer
                 }
                 break;
             case CMC:
-                panel.add(new JLabel(CollectionUtils.join(join, CollectionUtils.convertToList(value, Double.class))));
+                double cmc = value == null ? 0 : (Double)value;
+                panel.add(new JLabel(cmc == (int)cmc ? Integer.toString((int)cmc) : Double.toString(cmc)));
                 break;
             case COLORS:
             case COLOR_IDENTITY:

--- a/src/main/java/editor/gui/editor/CategoryPanel.java
+++ b/src/main/java/editor/gui/editor/CategoryPanel.java
@@ -194,9 +194,9 @@ public class CategoryPanel extends JPanel
     }
 
     /**
-     * Label showing the average CMC of cards in the category.
+     * Label showing the average manaValue of cards in the category.
      */
-    private JLabel avgCMCLabel;
+    private JLabel avgManaValueLabel;
     /**
      * Default background color of this panel.
      */
@@ -279,8 +279,8 @@ public class CategoryPanel extends JPanel
         countLabel = new JLabel("Cards: " + deck.getCategoryList(name).total());
         statsPanel.add(countLabel);
         statsPanel.add(ComponentUtils.createHorizontalSeparator(10, ComponentUtils.TEXT_SIZE));
-        avgCMCLabel = new JLabel("Average CMC: 0");
-        statsPanel.add(avgCMCLabel);
+        avgManaValueLabel = new JLabel("Average mana value: 0");
+        statsPanel.add(avgManaValueLabel);
         statsPanel.add(Box.createHorizontalGlue());
         topPanel.add(statsPanel, BorderLayout.WEST);
 
@@ -470,15 +470,15 @@ public class CategoryPanel extends JPanel
     {
         countLabel.setText("Cards: " + deck.getCategoryList(name).total());
 
-        var avgCMC = deck.stream()
+        var avgManaValue = deck.stream()
             .filter(deck.getCategorySpec(name)::includes)
             .flatMap((c) -> Collections.nCopies(deck.getEntry(c).count(), c.manaValue()).stream())
             .mapToDouble(Double::valueOf)
             .average().orElse(0);
-        if (avgCMC == (int)avgCMC)
-            avgCMCLabel.setText("Average CMC: " + (int)avgCMC);
+        if (avgManaValue == (int)avgManaValue)
+            avgManaValueLabel.setText("Average mana value: " + (int)avgManaValue);
         else
-            avgCMCLabel.setText("Average CMC: " + String.format("%.2f", avgCMC));
+            avgManaValueLabel.setText("Average mana value: " + String.format("%.2f", avgManaValue));
 
         border.setTitle(name);
         table.revalidate();

--- a/src/main/java/editor/gui/editor/CategoryPanel.java
+++ b/src/main/java/editor/gui/editor/CategoryPanel.java
@@ -472,7 +472,7 @@ public class CategoryPanel extends JPanel
 
         var avgCMC = deck.stream()
             .filter(deck.getCategorySpec(name)::includes)
-            .flatMap((c) -> Collections.nCopies(deck.getEntry(c).count(), c.cmc().stream().min((a, b) -> Double.compare(a, b)).orElse(0.0)).stream())
+            .flatMap((c) -> Collections.nCopies(deck.getEntry(c).count(), c.cmc()).stream())
             .mapToDouble(Double::valueOf)
             .average().orElse(0);
         if (avgCMC == (int)avgCMC)

--- a/src/main/java/editor/gui/editor/CategoryPanel.java
+++ b/src/main/java/editor/gui/editor/CategoryPanel.java
@@ -472,7 +472,7 @@ public class CategoryPanel extends JPanel
 
         var avgCMC = deck.stream()
             .filter(deck.getCategorySpec(name)::includes)
-            .flatMap((c) -> Collections.nCopies(deck.getEntry(c).count(), c.cmc()).stream())
+            .flatMap((c) -> Collections.nCopies(deck.getEntry(c).count(), c.manaValue()).stream())
             .mapToDouble(Double::valueOf)
             .average().orElse(0);
         if (avgCMC == (int)avgCMC)

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -1154,6 +1154,7 @@ public class EditorFrame extends JInternalFrame
         for (CategoryPanel category : categoryPanels)
             category.applySettings(this);
         startingHandSize = SettingsDialog.settings().editor.hand.size;
+        updateStats();
         update();
     }
 
@@ -2539,7 +2540,13 @@ public class EditorFrame extends JInternalFrame
 
         var manaValue = deck().current.stream()
             .filter((c) -> !c.typeContains("land"))
-            .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), c.manaValue()).stream())
+            .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), switch (SettingsDialog.settings().editor.manaValue) {
+                case "Minimum" -> c.minManaValue();
+                case "Maximum" -> c.maxManaValue();
+                case "Average" -> c.avgManaValue();
+                case "Real"    -> c.manaValue();
+                default -> Double.NaN;
+            }).stream())
             .sorted()
             .collect(Collectors.toList());
         double avgManaValue = manaValue.stream().mapToDouble(Double::valueOf).average().orElse(0);

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -2539,7 +2539,7 @@ public class EditorFrame extends JInternalFrame
 
         var cmc = deck().current.stream()
             .filter((c) -> !c.typeContains("land"))
-            .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), c.cmc()).stream())
+            .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), c.manaValue()).stream())
             .sorted()
             .collect(Collectors.toList());
         double avgCMC = cmc.stream().mapToDouble(Double::valueOf).average().orElse(0);

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -2539,7 +2539,7 @@ public class EditorFrame extends JInternalFrame
 
         var cmc = deck().current.stream()
             .filter((c) -> !c.typeContains("land"))
-            .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), c.cmc().stream().min(Double::compare).orElse(0.0)).stream())
+            .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), c.cmc()).stream())
             .sorted()
             .collect(Collectors.toList());
         double avgCMC = cmc.stream().mapToDouble(Double::valueOf).average().orElse(0);

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -441,9 +441,9 @@ public class EditorFrame extends JInternalFrame
     public static final int MAIN_DECK = 0;
 
     /**
-     * Label showing the average CMC of nonland cards in the deck.
+     * Label showing the average mana value of nonland cards in the deck.
      */
-    private JLabel avgCMCLabel;
+    private JLabel avgManaValueLabel;
     /**
      * Panel containing categories.
      */
@@ -501,9 +501,9 @@ public class EditorFrame extends JInternalFrame
      */
     private JTabbedPane listTabs;
     /**
-     * Label showing the median CMC of nonland cards in the deck.
+     * Label showing the median mana value of nonland cards in the deck.
      */
-    private JLabel medCMCLabel;
+    private JLabel medManaValueLabel;
     /**
      * Menu containing sideboards to move cards from the main deck to one at a time.
      */
@@ -1002,11 +1002,11 @@ public class EditorFrame extends JInternalFrame
         nonlandLabel = new JLabel();
         statsPanel.add(nonlandLabel);
         statsPanel.add(ComponentUtils.createHorizontalSeparator(10, ComponentUtils.TEXT_SIZE));
-        avgCMCLabel = new JLabel();
-        statsPanel.add(avgCMCLabel);
+        avgManaValueLabel = new JLabel();
+        statsPanel.add(avgManaValueLabel);
         statsPanel.add(ComponentUtils.createHorizontalSeparator(10, ComponentUtils.TEXT_SIZE));
-        medCMCLabel = new JLabel();
-        statsPanel.add(medCMCLabel);
+        medManaValueLabel = new JLabel();
+        statsPanel.add(medManaValueLabel);
         statsPanel.add(Box.createHorizontalGlue());
         updateStats();
         GridBagConstraints statsConstraints = new GridBagConstraints();
@@ -2537,29 +2537,29 @@ public class EditorFrame extends JInternalFrame
         landLabel.setText("Lands: " + deck().current.land());
         nonlandLabel.setText("Nonlands: " + deck().current.nonland());
 
-        var cmc = deck().current.stream()
+        var manaValue = deck().current.stream()
             .filter((c) -> !c.typeContains("land"))
             .flatMap((c) -> Collections.nCopies(deck().current.getEntry(c).count(), c.manaValue()).stream())
             .sorted()
             .collect(Collectors.toList());
-        double avgCMC = cmc.stream().mapToDouble(Double::valueOf).average().orElse(0);
-        if ((int)avgCMC == avgCMC)
-            avgCMCLabel.setText("Average CMC: " + (int)avgCMC);
+        double avgManaValue = manaValue.stream().mapToDouble(Double::valueOf).average().orElse(0);
+        if ((int)avgManaValue == avgManaValue)
+            avgManaValueLabel.setText("Average mana value: " + (int)avgManaValue);
         else
-            avgCMCLabel.setText(String.format("Average CMC: %.2f", avgCMC));
+            avgManaValueLabel.setText(String.format("Average mana value: %.2f", avgManaValue));
 
-        double medCMC = 0.0;
-        if (!cmc.isEmpty())
+        double medManaValue = 0.0;
+        if (!manaValue.isEmpty())
         {
-            if (cmc.size() % 2 == 0)
-                medCMC = (cmc.get(cmc.size()/2 - 1) + cmc.get(cmc.size()/2))/2;
+            if (manaValue.size() % 2 == 0)
+                medManaValue = (manaValue.get(manaValue.size()/2 - 1) + manaValue.get(manaValue.size()/2))/2;
             else
-                medCMC = cmc.get(cmc.size()/2);
+                medManaValue = manaValue.get(manaValue.size()/2);
         }
-        if ((int)medCMC == medCMC)
-            medCMCLabel.setText("Median CMC: " + (int)medCMC);
+        if ((int)medManaValue == medManaValue)
+            medManaValueLabel.setText("Median mana value: " + (int)medManaValue);
         else
-            medCMCLabel.setText(String.format("Median CMC: %.1f", medCMC));
+            medManaValueLabel.setText(String.format("Median mana value: %.1f", medManaValue));
     }
 
     /**

--- a/src/main/java/editor/gui/filter/FilterPanelFactory.java
+++ b/src/main/java/editor/gui/filter/FilterPanelFactory.java
@@ -53,7 +53,7 @@ public interface FilterPanelFactory
         return switch (filter.type()) {
             case NAME, RULES_TEXT, FLAVOR_TEXT, PRINTED_TEXT, ARTIST, PRINTED_TYPES -> new TextFilterPanel((TextFilter)filter);
             case POWER, TOUGHNESS, LOYALTY -> new VariableNumberFilterPanel((VariableNumberFilter)filter);
-            case CMC, CARD_NUMBER -> new NumberFilterPanel((NumberFilter)filter);
+            case MANA_VALUE, CARD_NUMBER -> new NumberFilterPanel((NumberFilter)filter);
             case COLORS, COLOR_IDENTITY -> new ColorFilterPanel((ColorFilter)filter);
             case LAYOUT          -> new OptionsFilterPanel<>((LayoutFilter)filter, CardLayout.values());
             case MANA_COST       -> new ManaCostFilterPanel((ManaCostFilter)filter);

--- a/src/main/java/editor/gui/filter/FilterPanelFactory.java
+++ b/src/main/java/editor/gui/filter/FilterPanelFactory.java
@@ -53,22 +53,22 @@ public interface FilterPanelFactory
         return switch (filter.type()) {
             case NAME, RULES_TEXT, FLAVOR_TEXT, PRINTED_TEXT, ARTIST, PRINTED_TYPES -> new TextFilterPanel((TextFilter)filter);
             case POWER, TOUGHNESS, LOYALTY -> new VariableNumberFilterPanel((VariableNumberFilter)filter);
-            case MANA_VALUE, CARD_NUMBER -> new NumberFilterPanel((NumberFilter)filter);
+            case MANA_VALUE, MIN_VALUE, MAX_VALUE, CARD_NUMBER -> new NumberFilterPanel((NumberFilter)filter);
             case COLORS, COLOR_IDENTITY -> new ColorFilterPanel((ColorFilter)filter);
-            case LAYOUT          -> new OptionsFilterPanel<>((LayoutFilter)filter, CardLayout.values());
-            case MANA_COST       -> new ManaCostFilterPanel((ManaCostFilter)filter);
-            case TYPE_LINE       -> new TypeLineFilterPanel((TypeLineFilter)filter);
-            case SUPERTYPE       -> new OptionsFilterPanel<>((SupertypeFilter)filter, SupertypeFilter.supertypeList);
-            case CARD_TYPE       -> new OptionsFilterPanel<>((CardTypeFilter)filter, CardTypeFilter.typeList);
-            case SUBTYPE         -> new OptionsFilterPanel<>((SubtypeFilter)filter, SubtypeFilter.subtypeList);
-            case EXPANSION  -> new OptionsFilterPanel<>((ExpansionFilter)filter, Expansion.expansions);
-            case BLOCK           -> new OptionsFilterPanel<>((BlockFilter)filter, Expansion.blocks);
-            case RARITY          -> new OptionsFilterPanel<>((RarityFilter)filter, Rarity.values());
-            case LEGAL_IN        -> new LegalityFilterPanel((LegalityFilter)filter);
-            case TAGS            -> new OptionsFilterPanel<>((TagsFilter)filter, Card.tags().stream().sorted().toArray(String[]::new));
-            case DEFAULTS        -> new DefaultsFilterPanel();
-            case NONE            -> new BinaryFilterPanel(false);
-            case ANY             -> new BinaryFilterPanel(true);
+            case LAYOUT    -> new OptionsFilterPanel<>((LayoutFilter)filter, CardLayout.values());
+            case MANA_COST -> new ManaCostFilterPanel((ManaCostFilter)filter);
+            case TYPE_LINE -> new TypeLineFilterPanel((TypeLineFilter)filter);
+            case SUPERTYPE -> new OptionsFilterPanel<>((SupertypeFilter)filter, SupertypeFilter.supertypeList);
+            case CARD_TYPE -> new OptionsFilterPanel<>((CardTypeFilter)filter, CardTypeFilter.typeList);
+            case SUBTYPE   -> new OptionsFilterPanel<>((SubtypeFilter)filter, SubtypeFilter.subtypeList);
+            case EXPANSION -> new OptionsFilterPanel<>((ExpansionFilter)filter, Expansion.expansions);
+            case BLOCK     -> new OptionsFilterPanel<>((BlockFilter)filter, Expansion.blocks);
+            case RARITY    -> new OptionsFilterPanel<>((RarityFilter)filter, Rarity.values());
+            case LEGAL_IN  -> new LegalityFilterPanel((LegalityFilter)filter);
+            case TAGS      -> new OptionsFilterPanel<>((TagsFilter)filter, Card.tags().stream().sorted().toArray(String[]::new));
+            case DEFAULTS  -> new DefaultsFilterPanel();
+            case NONE      -> new BinaryFilterPanel(false);
+            case ANY       -> new BinaryFilterPanel(true);
             default -> throw new IllegalArgumentException("No panel exists for filters of type " + filter.toString());
         };
     }

--- a/src/main/java/editor/gui/settings/Settings.java
+++ b/src/main/java/editor/gui/settings/Settings.java
@@ -405,13 +405,16 @@ public final class Settings
         public final HandSettings hand;
         /** @see LegalitySettings */
         public final LegalitySettings legality;
+        /** Which mana value of cards with multiple values to use. */
+        public final String manaValue;
 
         private EditorSettings(int recentsCount, List<String> recentsFiles,
                                  int explicits,
                                  List<CategorySpec> presetCategories, int categoryRows,
                                  List<CardAttribute> columns, Color stripe,
                                  int handSize, String handRounding, Color handBackground,
-                                 boolean searchForCommander, boolean main, boolean all, String list, String sideboard)
+                                 boolean searchForCommander, boolean main, boolean all, String list, String sideboard,
+                                 String manaValue)
         {
             this.recents = new RecentsSettings(recentsCount, recentsFiles);
             this.categories = new CategoriesSettings(presetCategories, categoryRows, explicits);
@@ -419,6 +422,7 @@ public final class Settings
             this.stripe = stripe;
             this.hand = new HandSettings(handSize, handRounding, handBackground);
             this.legality = new LegalitySettings(searchForCommander, main, all, list, sideboard);
+            this.manaValue = manaValue;
         }
 
         private EditorSettings()
@@ -429,6 +433,7 @@ public final class Settings
             stripe = new Color(0xCC, 0xCC, 0xCC, 0xFF);
             hand = new HandSettings();
             legality = new LegalitySettings();
+            manaValue = "Minimum";
         }
 
         @Override
@@ -464,10 +469,10 @@ public final class Settings
     /** Initial directory of file choosers. */
     public final String cwd;
 
-    protected Settings(String inventorySource, String inventoryFile, String inventoryVersionFile, DatabaseVersion inventoryVersion, String inventoryLocation, String inventoryScans, String imageSource, boolean imageLimitEnable, int imageLimit, String inventoryTags, UpdateFrequency inventoryUpdate, boolean inventoryWarn, List<CardAttribute> inventoryColumns, Color inventoryBackground, Color inventoryStripe, int recentsCount, List<String> recentsFiles, int explicits, List<CategorySpec> presetCategories, int categoryRows, List<CardAttribute> editorColumns, Color editorStripe, int handSize, String handRounding, Color handBackground, boolean searchForCommander, boolean main, boolean all, String list, String sideboard, String cwd)
+    protected Settings(String inventorySource, String inventoryFile, String inventoryVersionFile, DatabaseVersion inventoryVersion, String inventoryLocation, String inventoryScans, String imageSource, boolean imageLimitEnable, int imageLimit, String inventoryTags, UpdateFrequency inventoryUpdate, boolean inventoryWarn, List<CardAttribute> inventoryColumns, Color inventoryBackground, Color inventoryStripe, int recentsCount, List<String> recentsFiles, int explicits, List<CategorySpec> presetCategories, int categoryRows, List<CardAttribute> editorColumns, Color editorStripe, int handSize, String handRounding, Color handBackground, boolean searchForCommander, boolean main, boolean all, String list, String sideboard, String manaValue, String cwd)
     {
         this.inventory = new InventorySettings(inventorySource, inventoryFile, inventoryVersionFile, inventoryVersion, inventoryLocation, inventoryScans, imageSource, imageLimitEnable, imageLimit, inventoryTags, inventoryUpdate, inventoryWarn, inventoryColumns, inventoryBackground, inventoryStripe);
-        this.editor = new EditorSettings(recentsCount, recentsFiles, explicits, presetCategories, categoryRows, editorColumns, editorStripe, handSize, handRounding, handBackground, searchForCommander, main, all, list, sideboard);
+        this.editor = new EditorSettings(recentsCount, recentsFiles, explicits, presetCategories, categoryRows, editorColumns, editorStripe, handSize, handRounding, handBackground, searchForCommander, main, all, list, sideboard, manaValue);
         this.cwd = cwd;
     }
 

--- a/src/main/java/editor/gui/settings/SettingsBuilder.java
+++ b/src/main/java/editor/gui/settings/SettingsBuilder.java
@@ -49,6 +49,7 @@ public class SettingsBuilder
     private boolean all;
     private String list;
     private String sideboard;
+    private String manaValue;
     private String cwd;
 
     /**
@@ -107,6 +108,7 @@ public class SettingsBuilder
             all,
             list,
             sideboard,
+            manaValue,
             cwd
         );
     }
@@ -149,6 +151,7 @@ public class SettingsBuilder
         all = original.editor.legality.all;
         list = original.editor.legality.list;
         sideboard = original.editor.legality.sideboard;
+        manaValue = original.editor.manaValue;
         cwd = original.cwd;
 
         return this;
@@ -195,6 +198,7 @@ public class SettingsBuilder
      * <li>{@link Settings.EditorSettings.LegalitySettings#all}: <code>false</code>
      * <li>{@link Settings.EditorSettings.LegalitySettings#list}: <code>""</code>
      * <li>{@link Settings.EditorSettings.LegalitySettings#sideboard}: <code>""</code>
+     * <li>{@link Settings.EditorSettings#manaValue}: <code>"Minimum"</code>
      * <li>{@link Settings#cwd}: <code>$HOME</code>
      * </ul>
      * 
@@ -663,6 +667,20 @@ public class SettingsBuilder
     public SettingsBuilder sideboardName(String sideboard)
     {
         this.sideboard = sideboard;
+        return this;
+    }
+
+    /**
+     * Set which mana value is used for analysis when a card has multiple.
+     * Options are "Minimum," "Maximum," "Average," and "Real."
+     * 
+     * @param choice which mana value to use
+     * @return this SettingsBuilder
+     * @see Settings.EditorSettings#manaValue
+     */
+    public SettingsBuilder manaValue(String choice)
+    {
+        this.manaValue = choice;
         return this;
     }
 

--- a/src/main/java/editor/gui/settings/SettingsDialog.java
+++ b/src/main/java/editor/gui/settings/SettingsDialog.java
@@ -109,6 +109,11 @@ public class SettingsDialog extends JDialog
      * List of possible sites to download card images from.
      */
     public static final List<String> IMAGE_SOURCES = List.of("Scryfall", "Gatherer");
+    /**
+     * List of possible choices for mana value during analysis for cards that have
+     * more than one.
+     */
+    public static final List<String> MANA_VALUE_OPTIONS = List.of("Minimum", "Maximum", "Average", "Real");
 
     /**
      * Create the preview panel for a color chooser that customizes the stripe color
@@ -332,6 +337,8 @@ public class SettingsDialog extends JDialog
     private JCheckBox limitImageBox;
     /** Spinner containing the number of cached image to allow. */
     private JSpinner limitImageSpinner;
+    /** Combo box showing possible ways to analyze mana value. */
+    private JComboBox<String> manaValueBox;
 
     /**
      * Create a new SettingsDialog.
@@ -575,6 +582,17 @@ public class SettingsDialog extends JDialog
         explicitsPanel.setMaximumSize(new Dimension(explicitsPanel.getPreferredSize().width + 5, explicitsPanel.getPreferredSize().height));
         explicitsPanel.setAlignmentX(LEFT_ALIGNMENT);
         editorPanel.add(explicitsPanel);
+        editorPanel.add(Box.createVerticalStrut(5));
+
+        // Mana value choice for analysis
+        JPanel manaValuePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        manaValuePanel.add(new JLabel("Mana value to analyze:"));
+        manaValuePanel.add(Box.createHorizontalStrut(5));
+        manaValueBox = new JComboBox<>(MANA_VALUE_OPTIONS.toArray(String[]::new));
+        manaValuePanel.add(manaValueBox);
+        manaValuePanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, manaValuePanel.getPreferredSize().height));
+        manaValuePanel.setAlignmentX(LEFT_ALIGNMENT);
+        editorPanel.add(manaValuePanel);
         editorPanel.add(Box.createVerticalStrut(5));
 
         editorPanel.add(Box.createVerticalGlue());
@@ -828,6 +846,7 @@ public class SettingsDialog extends JDialog
                 scanBGChooser.setColor(settings.inventory.background);
                 recentSpinner.getModel().setValue(settings.editor.recents.count);
                 explicitsSpinner.getModel().setValue(Integer.valueOf(settings.editor.categories.explicits));
+                manaValueBox.setSelectedIndex(Math.max(MANA_VALUE_OPTIONS.indexOf(settings.editor.manaValue), 0));
                 for (CategorySpec preset : settings.editor.categories.presets)
                     categoriesList.addCategory(new CategorySpec(preset));
                 rowsSpinner.getModel().setValue(settings.editor.categories.rows);
@@ -898,6 +917,7 @@ public class SettingsDialog extends JDialog
                 .inventoryStripe(inventoryStripeColor.getColor())
                 .recentsCount((Integer)recentSpinner.getValue())
                 .explicits((Integer)explicitsSpinner.getValue())
+                .manaValue(manaValueBox.getItemAt(manaValueBox.getSelectedIndex()))
                 .categoryRows((Integer)rowsSpinner.getValue())
                 .editorColumns(editorColumnCheckBoxes.entrySet().stream().filter((e) -> e.getValue().isSelected()).map(Map.Entry::getKey).sorted().collect(Collectors.toList()))
                 .editorStripe(editorStripeColor.getColor())

--- a/src/main/java/editor/serialization/legacy/FilterDeserializer.java
+++ b/src/main/java/editor/serialization/legacy/FilterDeserializer.java
@@ -48,7 +48,7 @@ public interface FilterDeserializer
         new SimpleImmutableEntry<>("l", CardAttribute.LOYALTY),
         new SimpleImmutableEntry<>("a", CardAttribute.ARTIST),
         new SimpleImmutableEntry<>("#", CardAttribute.CARD_NUMBER),
-        new SimpleImmutableEntry<>("cmc", CardAttribute.CMC),
+        new SimpleImmutableEntry<>("cmc", CardAttribute.MANA_VALUE),
         new SimpleImmutableEntry<>("c", CardAttribute.COLORS),
         new SimpleImmutableEntry<>("ci", CardAttribute.COLOR_IDENTITY),
         new SimpleImmutableEntry<>("f", CardAttribute.FLAVOR_TEXT),
@@ -104,7 +104,7 @@ public interface FilterDeserializer
                 mana.contain = (Containment)in.readObject();
                 mana.cost = ManaCost.parseManaCost(in.readUTF());
                 return mana;
-            case CMC:
+            case MANA_VALUE:
             case CARD_NUMBER:
                 NumberFilter number = (NumberFilter)type.get();
                 number.operand = in.readDouble();


### PR DESCRIPTION
- Change CMC to mana value as it is now templated
- Change mana value function to return a single double, as all cards now only have one mana value
- Since some cards have multiple options for casting them, and always using their true mana values is not necessarily useful for analyzing a deck, add functions to Card to compute minimum, maximum, and average mana values of all of its faces
- Add filters for minimum and maximum mana values (original mana value filter now filters for true mana value); average is excluded here for now
- Add a setting to choose which mana value to use for the deck stats at the bottom of the editor frame