### PR TITLE
Properly close the application

### DIFF
--- a/src/main/java/editor/gui/MainFrame.java
+++ b/src/main/java/editor/gui/MainFrame.java
@@ -1724,7 +1724,8 @@ public class MainFrame extends JFrame
         if (closeAll())
         {
             saveSettings();
-            System.exit(0);
+            setVisible(false);
+            dispose();
         }
     }
 


### PR DESCRIPTION
Dispose of windows and have Swing automatically terminate rather than calling `System.exit(.)`.