### PR TITLE
Multi-faced Cards with Lands on the Back

### DIFF
--- a/src/main/java/editor/collection/deck/Deck.java
+++ b/src/main/java/editor/collection/deck/Deck.java
@@ -417,10 +417,6 @@ public class Deck implements CardList
      * Total number of cards in this Deck, accounting for multiples.
      */
     private int total;
-    /**
-     * Number of land cards in this Deck, accounting for multiples.
-     */
-    private int land;
 
     /**
      * Create a new, empty Deck with no categories.
@@ -430,7 +426,6 @@ public class Deck implements CardList
         masterList = new ArrayList<>();
         categories = new LinkedHashMap<>();
         total = 0;
-        land = 0;
     }
 
     /**
@@ -490,8 +485,6 @@ public class Deck implements CardList
         }
         entry.add(amount);
         total += amount;
-        if (card.isLand())
-            land += amount;
 
         return true;
     }
@@ -581,7 +574,6 @@ public class Deck implements CardList
         masterList.clear();
         categories.clear();
         total = 0;
-        land = 0;
     }
 
     @Override
@@ -738,26 +730,6 @@ public class Deck implements CardList
     }
 
     /**
-     * Get the number of lands in the deck.
-     *
-     * @return the number of land cards, including multiples.
-     */
-    public int land()
-    {
-        return land;
-    }
-
-    /**
-     * Get the number of nonlands in the deck.
-     *
-     * @return the number of nonland cards, including multiples.
-     */
-    public int nonland()
-    {
-        return total - land;
-    }
-
-    /**
      * Get the number of categories in the deck.
      *
      * @return the number of categories.
@@ -799,8 +771,6 @@ public class Deck implements CardList
                 masterList.remove(entry);
             }
             total -= removed;
-            if (card.isLand())
-                land -= removed;
         }
 
         return removed;
@@ -893,8 +863,6 @@ public class Deck implements CardList
         else
         {
             total += amount - e.count;
-            if (e.card.isLand())
-                land += amount - e.count;
 
             var change = new HashMap<Card, Integer>();
             change.put(card, amount - e.count);

--- a/src/main/java/editor/database/card/Card.java
+++ b/src/main/java/editor/database/card/Card.java
@@ -66,10 +66,6 @@ public abstract class Card
      */
     private final Expansion expansion;
     /**
-     * Number of faces this Card has.
-     */
-    private final int faces;
-    /**
      * Whether or not to ignore the card count restriction for this Card.
      */
     private Lazy<Boolean> ignoreCountRestriction;
@@ -113,13 +109,11 @@ public abstract class Card
      *
      * @param expansion expension the new Card belongs to
      * @param layout layout of the new Card
-     * @param faces number of faces the new Card has
      */
-    public Card(Expansion expansion, CardLayout layout, int faces)
+    public Card(Expansion expansion, CardLayout layout)
     {
         this.expansion = expansion;
         this.layout = layout;
-        this.faces = faces;
 
         normalizedName = new Lazy<>(() -> Collections.unmodifiableList(name().stream().map(UnicodeSymbols::normalize).collect(Collectors.toList())));
         legendName = new Lazy<>(() -> {
@@ -154,8 +148,8 @@ public abstract class Card
             return Collections.unmodifiableList(legendNames);
         });
         normalizedOracle = new Lazy<>(() -> {
-            var texts = new ArrayList<String>(faces);
-            for (int i = 0; i < faces; i++)
+            var texts = new ArrayList<String>(oracleText().size());
+            for (int i = 0; i < oracleText().size(); i++)
             {
                 String normal = UnicodeSymbols.normalize(oracleText().get(i).toLowerCase());
                 normal = normal.replace(legendName().get(i), Card.THIS).replace(normalizedName().get(i), Card.THIS);
@@ -262,16 +256,6 @@ public abstract class Card
     public Expansion expansion()
     {
         return expansion;
-    }
-
-    /**
-     * Get the number of faces this Card has.
-     *
-     * @return the number of faces
-     */
-    public int faces()
-    {
-        return faces;
     }
 
     /**

--- a/src/main/java/editor/database/card/MultiCard.java
+++ b/src/main/java/editor/database/card/MultiCard.java
@@ -30,107 +30,54 @@ import editor.util.Lazy;
  */
 public abstract class MultiCard extends Card
 {
-    /**
-     * List containing the set of types for each of this MultiCard's faces.
-     */
-    private Lazy<List<Set<String>>> allTypes;
-    /**
-     * List containing the artist of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> artist;
-    /**
-     * Tuple of the color identity of this MultiCard.
-     */
-    private Lazy<List<ManaType>> colorIdentity;
-    /**
-     * Tuple of all of the colors of this MultiCard.
-     */
-    private Lazy<List<ManaType>> colors;
-    /**
-     * List of formats this MultiCard can be commander in.
-     */
-    private Lazy<List<String>> commandFormats;
-    /**
-     * List of Cards that represent faces.  They should all have exactly one face.
-     */
-    private List<? extends Card> faces;
-    /**
-     * List containing the flavor text of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> flavorText;
-    /**
-     * List containing the image name of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> imageNames;
-    /**
-     * Whether or not this MultiCard is a land card, which it only is if its front
-     * (first) face is a land.
-     */
-    private boolean isLand;
-    /**
-     * Tuple containing the loyalty of each of this MultiCard's faces.
-     */
-    private Lazy<List<Loyalty>> loyalty;
-    /**
-     * List of mana costs of the faces of this MultiCard.
-     */
-    private Lazy<List<ManaCost>> manaCost;
-    /**
-     * List of the names of the faces of this MultiCard.
-     */
-    private Lazy<List<String>> name;
-    /**
-     * List containing the collector's number of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> number;
-    /**
-     * List containing this MultiCard's faces' multiverseids.
-     */
-    private Lazy<List<Integer>> multiverseid;
-    /**
-     * List containing this MultiCard's faces' Scryfall illustration ids.
-     */
-    private Lazy<List<String>> scryfallid;
-    /**
-     * List containing the oracle text of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> oracleText;
-    /**
-     * Tuple containing the power of each of this MultiCard's faces.
-     */
-    private Lazy<List<CombatStat>> power;
-    /**
-     * List containing the printed text of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> printedText;
-    /**
-     * List containing the printed type lines of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> printedTypes;
-    /**
-     * Map containing the rulings of this MultiCard and the dates they were made on.
-     */
-    private Lazy<Map<Date, List<String>>> rulings;
-    /**
-     * Set of this MultiCard's subtypes including all of its faces.
-     */
-    private Lazy<Set<String>> subtypes;
-    /**
-     * Set of this MultiCard's supertypes including all of its faces.
-     */
-    private Lazy<Set<String>> supertypes;
-    /**
-     * Tuple containing the toughness of each of this MultiCard's faces.
-     */
-    private Lazy<List<CombatStat>> toughness;
-    /**
-     * List containing the type line of each of this MultiCard's faces.
-     */
-    private Lazy<List<String>> typeLine;
-    /**
-     * Set of this MultiCard's types including all of its faces.
-     */
-    private Lazy<Set<String>> types;
+    /** List containing the set of types for each of this MultiCard's faces. */
+    private final Lazy<List<Set<String>>> allTypes;
+    /** List containing the artist of each of this MultiCard's faces. */
+    private final Lazy<List<String>> artist;
+    /** Tuple of the color identity of this MultiCard. */
+    private final Lazy<List<ManaType>> colorIdentity;
+    /** Tuple of all of the colors of this MultiCard. */
+    private final Lazy<List<ManaType>> colors;
+    /** List of formats this MultiCard can be commander in. */
+    private final Lazy<List<String>> commandFormats;
+    /** List of Cards that represent faces.  They should all be {@link SingleCard}s */
+    private final List<? extends Card> faces;
+    /** List containing the flavor text of each of this MultiCard's faces. */
+    private final Lazy<List<String>> flavorText;
+    /** List containing the image name of each of this MultiCard's faces. */
+    private final Lazy<List<String>> imageNames;
+    /** Tuple containing the loyalty of each of this MultiCard's faces. */
+    private final Lazy<List<Loyalty>> loyalty;
+    /** List of mana costs of the faces of this MultiCard. */
+    private final Lazy<List<ManaCost>> manaCost;
+    /** List of the names of the faces of this MultiCard.*/
+    private final Lazy<List<String>> name;
+    /** List containing the collector's number of each of this MultiCard's faces. */
+    private final Lazy<List<String>> number;
+    /** List containing this MultiCard's faces' multiverseids. */
+    private final Lazy<List<Integer>> multiverseid;
+    /** List containing this MultiCard's faces' Scryfall illustration ids. */
+    private final Lazy<List<String>> scryfallid;
+    /** List containing the oracle text of each of this MultiCard's faces. */
+    private final Lazy<List<String>> oracleText;
+    /** Tuple containing the power of each of this MultiCard's faces. */
+    private final Lazy<List<CombatStat>> power;
+    /** List containing the printed text of each of this MultiCard's faces. */
+    private final Lazy<List<String>> printedText;
+    /** List containing the printed type lines of each of this MultiCard's faces. */
+    private final Lazy<List<String>> printedTypes;
+    /** Map containing the rulings of this MultiCard and the dates they were made on. */
+    private final Lazy<Map<Date, List<String>>> rulings;
+    /** Set of this MultiCard's subtypes including all of its faces. */
+    private final Lazy<Set<String>> subtypes;
+    /** Set of this MultiCard's supertypes including all of its faces. */
+    private final Lazy<Set<String>> supertypes;
+    /** Tuple containing the toughness of each of this MultiCard's faces. */
+    private final Lazy<List<CombatStat>> toughness;
+    /** List containing the type line of each of this MultiCard's faces. */
+    private final Lazy<List<String>> typeLine;
+    /** Set of this MultiCard's types including all of its faces. */
+    private final Lazy<Set<String>> types;
 
     /**
      * Create a new MultiCard out of the given cards.
@@ -147,15 +94,15 @@ public abstract class MultiCard extends Card
      * Create a new MultiCard out of the given list of Cards. Each one should only have one face.
      *
      * @param layout layout of the new MultiCard, which should be one that has multiple faces
-     * @param f      cards to use as faces
+     * @param f cards to use as faces
      */
     public MultiCard(CardLayout layout, List<? extends Card> f)
     {
-        super(f.get(0).expansion(), layout, f.size());
+        super(f.get(0).expansion(), layout);
 
-        faces = f;
+        faces = Collections.unmodifiableList(f);
         for (Card face : faces)
-            if (face.faces() > 1)
+            if (face instanceof MultiCard)
                 throw new IllegalArgumentException("Only normal, single-faced cards can be joined into a multi-faced card");
 
         name = new Lazy<>(() -> collect(Card::name));
@@ -203,7 +150,6 @@ public abstract class MultiCard extends Card
         imageNames = new Lazy<>(() -> collect(Card::imageNames));
         multiverseid = new Lazy<>(() -> collect(Card::multiverseid));
         scryfallid = new Lazy<>(() -> collect(Card::scryfallid));
-        isLand = faces.get(0).isLand() || (layout == CardLayout.MODAL_DFC && faces.get(1).isLand());
         commandFormats = new Lazy<>(() -> faces.stream().flatMap((c) -> c.commandFormats().stream()).distinct().sorted().collect(Collectors.toList()));
     }
 
@@ -269,7 +215,7 @@ public abstract class MultiCard extends Card
     @Override
     public boolean isLand()
     {
-        return isLand;
+        throw new UnsupportedOperationException("look at individual faces to determine if " + unifiedName() + " is a land");
     }
 
     @Override
@@ -421,5 +367,10 @@ public abstract class MultiCard extends Card
     public void formatDocument(StyledDocument document, boolean printed, int f)
     {
         faces.get(f).formatDocument(document, printed);
+    }
+
+    public List<? extends Card> faces()
+    {
+        return faces;
     }
 }

--- a/src/main/java/editor/database/card/MultiCard.java
+++ b/src/main/java/editor/database/card/MultiCard.java
@@ -203,7 +203,7 @@ public abstract class MultiCard extends Card
         imageNames = new Lazy<>(() -> collect(Card::imageNames));
         multiverseid = new Lazy<>(() -> collect(Card::multiverseid));
         scryfallid = new Lazy<>(() -> collect(Card::scryfallid));
-        isLand = faces.get(0).isLand();
+        isLand = faces.get(0).isLand() || (layout == CardLayout.MODAL_DFC && faces.get(1).isLand());
         commandFormats = new Lazy<>(() -> faces.stream().flatMap((c) -> c.commandFormats().stream()).distinct().sorted().collect(Collectors.toList()));
     }
 

--- a/src/main/java/editor/database/card/SingleCard.java
+++ b/src/main/java/editor/database/card/SingleCard.java
@@ -198,7 +198,7 @@ public class SingleCard extends Card
                       Map<String, Legality> legality,
                       List<String> command)
     {
-        super(set, layout, 1);
+        super(set, layout);
 
         this.name = name;
         this.mana = mana;

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -78,6 +78,7 @@ import editor.collection.deck.Deck;
 import editor.collection.deck.Hand;
 import editor.collection.export.CardListFormat;
 import editor.database.card.Card;
+import editor.database.card.MultiCard;
 import editor.gui.CardTagPanel;
 import editor.gui.MainFrame;
 import editor.gui.TableSelectionListener;
@@ -2533,7 +2534,14 @@ public class EditorFrame extends JInternalFrame
      */
     public void updateStats()
     {
-        int lands = deck().current.stream().filter(Card::isLand).mapToInt((c) -> deck().current.getEntry(c).count()).sum();
+        int lands = deck().current.stream().filter((c) -> {
+            if (c instanceof MultiCard m)
+                return switch (m.layout()) {
+                    case MODAL_DFC -> m.faces().stream().anyMatch(Card::isLand);
+                    default -> m.faces().get(0).isLand();
+                };
+            return c.isLand();
+        }).mapToInt((c) -> deck().current.getEntry(c).count()).sum();
         countLabel.setText("Total cards: " + deck().current.total());
         landLabel.setText("Lands: " + lands);
         nonlandLabel.setText("Nonlands: " + (deck().current.total() - lands));

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -2536,10 +2536,14 @@ public class EditorFrame extends JInternalFrame
     {
         int lands = deck().current.stream().filter((c) -> {
             if (c instanceof MultiCard m)
-                return switch (m.layout()) {
-                    case MODAL_DFC -> m.faces().stream().anyMatch(Card::isLand);
-                    default -> m.faces().get(0).isLand();
-                };
+            {
+                if (Arrays.stream(editor.database.card.CardLayout.values())
+                        .filter((l) -> l.isMultiFaced)
+                        .anyMatch((l) -> SettingsDialog.settings().editor().backFaceLands().contains(l)))
+                    return m.faces().stream().anyMatch(Card::isLand);
+                else
+                    return m.faces().get(0).isLand();
+            }
             return c.isLand();
         }).mapToInt((c) -> deck().current.getEntry(c).count()).sum();
         countLabel.setText("Total cards: " + deck().current.total());

--- a/src/main/java/editor/gui/editor/EditorFrame.java
+++ b/src/main/java/editor/gui/editor/EditorFrame.java
@@ -2533,9 +2533,10 @@ public class EditorFrame extends JInternalFrame
      */
     public void updateStats()
     {
+        int lands = deck().current.stream().filter(Card::isLand).mapToInt((c) -> deck().current.getEntry(c).count()).sum();
         countLabel.setText("Total cards: " + deck().current.total());
-        landLabel.setText("Lands: " + deck().current.land());
-        nonlandLabel.setText("Nonlands: " + deck().current.nonland());
+        landLabel.setText("Lands: " + lands);
+        nonlandLabel.setText("Nonlands: " + (deck().current.total() - lands));
 
         var manaValue = deck().current.stream()
             .filter((c) -> !c.typeContains("land"))

--- a/src/main/java/editor/gui/settings/Settings.java
+++ b/src/main/java/editor/gui/settings/Settings.java
@@ -14,10 +14,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import editor.collection.deck.CategorySpec;
 import editor.database.attributes.CardAttribute;
+import editor.database.card.CardLayout;
 import editor.database.version.DatabaseVersion;
 import editor.database.version.UpdateFrequency;
 import editor.filter.leaf.options.multi.CardTypeFilter;
@@ -127,7 +129,8 @@ public record Settings(InventorySettings inventory, EditorSettings editor, Strin
         Color stripe,
         HandSettings hand,
         LegalitySettings legality,
-        String manaValue)
+        String manaValue,
+        Set<CardLayout> backFaceLands)
     {
         /**
          * Sub-structure containing information about recently-edited files.
@@ -200,7 +203,8 @@ public record Settings(InventorySettings inventory, EditorSettings editor, Strin
                                List<CardAttribute> columns, Color stripe,
                                int handSize, String handRounding, Color handBackground,
                                boolean searchForCommander, boolean main, boolean all, String list, String sideboard,
-                               String manaValue)
+                               String manaValue,
+                               Set<CardLayout> backFaceLands)
         {
             this(
                 new RecentsSettings(recentsCount, recentsFiles),
@@ -209,7 +213,8 @@ public record Settings(InventorySettings inventory, EditorSettings editor, Strin
                 stripe,
                 new HandSettings(handSize, handRounding, handBackground),
                 new LegalitySettings(searchForCommander, main, all, list, sideboard),
-                manaValue
+                manaValue,
+                backFaceLands
             );
         }
 
@@ -222,16 +227,17 @@ public record Settings(InventorySettings inventory, EditorSettings editor, Strin
                 new Color(0xCC, 0xCC, 0xCC, 0xFF),
                 new HandSettings(),
                 new LegalitySettings(),
-                "Minimum"
+                "Minimum",
+                Set.of(CardLayout.MODAL_DFC)
             );
         }
     }
 
-    protected Settings(String inventorySource, String inventoryFile, String inventoryVersionFile, DatabaseVersion inventoryVersion, String inventoryLocation, String inventoryScans, String imageSource, boolean imageLimitEnable, int imageLimit, String inventoryTags, UpdateFrequency inventoryUpdate, boolean inventoryWarn, List<CardAttribute> inventoryColumns, Color inventoryBackground, Color inventoryStripe, int recentsCount, List<String> recentsFiles, int explicits, List<CategorySpec> presetCategories, int categoryRows, List<CardAttribute> editorColumns, Color editorStripe, int handSize, String handRounding, Color handBackground, boolean searchForCommander, boolean main, boolean all, String list, String sideboard, String manaValue, String cwd)
+    protected Settings(String inventorySource, String inventoryFile, String inventoryVersionFile, DatabaseVersion inventoryVersion, String inventoryLocation, String inventoryScans, String imageSource, boolean imageLimitEnable, int imageLimit, String inventoryTags, UpdateFrequency inventoryUpdate, boolean inventoryWarn, List<CardAttribute> inventoryColumns, Color inventoryBackground, Color inventoryStripe, int recentsCount, List<String> recentsFiles, int explicits, List<CategorySpec> presetCategories, int categoryRows, List<CardAttribute> editorColumns, Color editorStripe, int handSize, String handRounding, Color handBackground, boolean searchForCommander, boolean main, boolean all, String list, String sideboard, String manaValue, Set<CardLayout> backFaceLands, String cwd)
     {
         this(
             new InventorySettings(inventorySource, inventoryFile, inventoryVersionFile, inventoryVersion, inventoryLocation, inventoryScans, imageSource, imageLimitEnable, imageLimit, inventoryTags, inventoryUpdate, inventoryWarn, inventoryColumns, inventoryBackground, inventoryStripe),
-            new EditorSettings(recentsCount, recentsFiles, explicits, presetCategories, categoryRows, editorColumns, editorStripe, handSize, handRounding, handBackground, searchForCommander, main, all, list, sideboard, manaValue),
+            new EditorSettings(recentsCount, recentsFiles, explicits, presetCategories, categoryRows, editorColumns, editorStripe, handSize, handRounding, handBackground, searchForCommander, main, all, list, sideboard, manaValue, backFaceLands),
             cwd
         );
     }

--- a/src/main/java/editor/gui/settings/Settings.java
+++ b/src/main/java/editor/gui/settings/Settings.java
@@ -119,6 +119,7 @@ public record Settings(InventorySettings inventory, EditorSettings editor, Strin
      * @param hand {@link HandSettings}
      * @param legality {@link LegalitySettings}
      * @param manaValue which mana value of cards with multiple values to use
+     * @param backFaceLands which multi-faced layouts count as lands when back faces are lands
      * 
      * @author Alec Roelke
      */

--- a/src/main/java/editor/gui/settings/SettingsBuilder.java
+++ b/src/main/java/editor/gui/settings/SettingsBuilder.java
@@ -4,10 +4,12 @@ import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import editor.collection.deck.CategorySpec;
 import editor.database.attributes.CardAttribute;
+import editor.database.card.CardLayout;
 import editor.database.version.DatabaseVersion;
 import editor.database.version.UpdateFrequency;
 
@@ -50,13 +52,13 @@ public class SettingsBuilder
     private String list;
     private String sideboard;
     private String manaValue;
+    private Set<CardLayout> backFaceLands;
     private String cwd;
 
     /**
      * Create a new SettingsBuilder with nothing set.
      */
-    public SettingsBuilder()
-    {}
+    public SettingsBuilder() {}
 
     /**
      * Create a new SettingsBuilder that is prepared to copy a settings
@@ -109,6 +111,7 @@ public class SettingsBuilder
             list,
             sideboard,
             manaValue,
+            backFaceLands,
             cwd
         );
     }
@@ -152,6 +155,7 @@ public class SettingsBuilder
         list = original.editor().legality().list();
         sideboard = original.editor().legality().sideboard();
         manaValue = original.editor().manaValue();
+        backFaceLands = original.editor().backFaceLands();
         cwd = original.cwd();
 
         return this;
@@ -199,6 +203,7 @@ public class SettingsBuilder
      * <li>{@link Settings.EditorSettings.LegalitySettings#list}: <code>""</code>
      * <li>{@link Settings.EditorSettings.LegalitySettings#sideboard}: <code>""</code>
      * <li>{@link Settings.EditorSettings#manaValue}: <code>"Minimum"</code>
+     * <li>{@link Settings.EditorSettings#backFaceLands}: [{@link CardLayout#MODAL_DFC}]
      * <li>{@link Settings#cwd}: <code>$HOME</code>
      * </ul>
      * 
@@ -681,6 +686,20 @@ public class SettingsBuilder
     public SettingsBuilder manaValue(String choice)
     {
         this.manaValue = choice;
+        return this;
+    }
+
+    /**
+     * Set which layouts (which must be multi-faced) to count as lands if their back faces
+     * are lands
+     * 
+     * @param choices set of card layouts to count as lands
+     * @return this SettingsBuilder
+     * @see Settings.EditorSettings#backFaceLands
+     */
+    public SettingsBuilder backFaceLands(Set<CardLayout> choices)
+    {
+        this.backFaceLands = choices;
         return this;
     }
 

--- a/src/main/java/editor/gui/settings/SettingsDialog.java
+++ b/src/main/java/editor/gui/settings/SettingsDialog.java
@@ -338,6 +338,8 @@ public class SettingsDialog extends JDialog
     private JSpinner limitImageSpinner;
     /** Combo box showing possible ways to analyze mana value. */
     private JComboBox<String> manaValueBox;
+    /** Check boxes indicating which layouts to count as lands if their back faces are lands. */
+    private List<JCheckBox> landsCheckBoxes;
 
     /**
      * Create a new SettingsDialog.
@@ -592,6 +594,17 @@ public class SettingsDialog extends JDialog
         manaValuePanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, manaValuePanel.getPreferredSize().height));
         manaValuePanel.setAlignmentX(LEFT_ALIGNMENT);
         editorPanel.add(manaValuePanel);
+        editorPanel.add(Box.createVerticalStrut(5));
+
+        // Which layouts to count lands on back sides
+        JPanel landsPanel = new JPanel(new FlowLayout(0, 0, FlowLayout.LEADING));
+        landsPanel.setBorder(BorderFactory.createTitledBorder("Count lands on back sides for layouts:"));
+        landsCheckBoxes = Arrays.stream(editor.database.card.CardLayout.values()).filter((l) -> l.isMultiFaced).map((l) -> new JCheckBox(l.toString(), settings.editor().backFaceLands().contains(l))).collect(Collectors.toList());
+        for (JCheckBox box : landsCheckBoxes)
+            landsPanel.add(box);
+        landsPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, landsPanel.getPreferredSize().height));
+        landsPanel.setAlignmentX(LEFT_ALIGNMENT);
+        editorPanel.add(landsPanel);
         editorPanel.add(Box.createVerticalStrut(5));
 
         editorPanel.add(Box.createVerticalGlue());
@@ -917,6 +930,7 @@ public class SettingsDialog extends JDialog
                 .recentsCount((Integer)recentSpinner.getValue())
                 .explicits((Integer)explicitsSpinner.getValue())
                 .manaValue(manaValueBox.getItemAt(manaValueBox.getSelectedIndex()))
+                .backFaceLands(landsCheckBoxes.stream().filter(JCheckBox::isSelected).map((b) -> Arrays.stream(editor.database.card.CardLayout.values()).filter((l) -> l.toString().equals(b.getText())).findAny().get()).collect(Collectors.toSet()))
                 .categoryRows((Integer)rowsSpinner.getValue())
                 .editorColumns(editorColumnCheckBoxes.entrySet().stream().filter((e) -> e.getValue().isSelected()).map(Map.Entry::getKey).sorted().collect(Collectors.toList()))
                 .editorStripe(editorStripeColor.getColor())

--- a/src/main/java/editor/serialization/SettingsAdapter.java
+++ b/src/main/java/editor/serialization/SettingsAdapter.java
@@ -36,75 +36,143 @@ public class SettingsAdapter implements JsonSerializer<Settings>, JsonDeserializ
     @Override
     public Settings deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
     {
+        SettingsBuilder builder = new SettingsBuilder().defaults();
         JsonObject obj = json.getAsJsonObject();
-        JsonObject inventory = obj.get("inventory").getAsJsonObject();
-        JsonObject editor = obj.get("editor").getAsJsonObject();
-        JsonObject recents = editor.get("recents").getAsJsonObject();
-        JsonObject categories = editor.get("categories").getAsJsonObject();
-        JsonObject hand = editor.get("hand").getAsJsonObject();
-        JsonObject legality = editor.get("legality").getAsJsonObject();
 
-        JsonArray inventoryColumnsJson = inventory.get("columns").getAsJsonArray();
-        var inventoryColumns = new ArrayList<CardAttribute>(inventoryColumnsJson.size());
-        for (var column : inventoryColumnsJson)
-            inventoryColumns.add(context.deserialize(column, CardAttribute.class));
+        if (obj.has("inventory"))
+        {
+            JsonObject inventory = obj.get("inventory").getAsJsonObject();
 
-        JsonArray recentsJson = recents.get("files").getAsJsonArray();
-        var recentsFiles = new ArrayList<String>(recentsJson.size());
-        for (var file : recentsJson)
-            recentsFiles.add(file.getAsString());
+            if (inventory.has("source"))
+                builder = builder.inventorySource(inventory.get("source").getAsString());
+            if (inventory.has("file"))
+                builder = builder.inventoryFile(inventory.get("file").getAsString());
+            if (inventory.has("versionFile"))
+                builder = builder.inventoryVersionFile(inventory.get("versionFile").getAsString());
+            if (inventory.has("version"))
+                builder = builder.inventoryVersion(context.deserialize(inventory.get("version"), DatabaseVersion.class));
+            if (inventory.has("location"))
+                builder = builder.inventoryLocation(inventory.get("location").getAsString());
+            if (inventory.has("scans"))
+                builder = builder.inventoryScans(inventory.get("scans").getAsString());
+            if (inventory.has("imageSource"))
+                builder = builder.imageSource(inventory.get("imageSource").getAsString());
+            if (inventory.has("imageLimitEnable"))
+                builder = builder.imageLimitEnable(inventory.get("imageLimitEnable").getAsBoolean());
+            if (inventory.has("imageLimit"))
+                builder = builder.imageLimit(inventory.get("imageLimit").getAsInt());
+            if (inventory.has("tags"))
+                builder = builder.inventoryTags(inventory.get("tags").getAsString());
+            if (inventory.has("update"))
+                builder = builder.inventoryUpdate(context.deserialize(inventory.get("update"), UpdateFrequency.class));
+            if (inventory.has("columns"))
+            {
+                JsonArray inventoryColumnsJson = inventory.get("columns").getAsJsonArray();
+                var inventoryColumns = new ArrayList<CardAttribute>(inventoryColumnsJson.size());
+                for (var column : inventoryColumnsJson)
+                    inventoryColumns.add(context.deserialize(column, CardAttribute.class));
+                builder = builder.inventoryColumns(inventoryColumns);
+            }
+            if (inventory.has("background"))
+                builder = builder.inventoryBackground(context.deserialize(inventory.get("background"), Color.class));
+            if (inventory.has("stripe"))
+                builder = builder.inventoryStripe(context.deserialize(inventory.get("stripe"), Color.class));
+            if (inventory.has("warn"))
+                builder = builder.inventoryWarn(inventory.get("warn").getAsBoolean());
+        }
 
-        JsonArray presetsJson = categories.get("presets").getAsJsonArray();
-        var presets = new ArrayList<CategorySpec>(presetsJson.size());
-        for (var preset : presetsJson)
-            presets.add(context.deserialize(preset, CategorySpec.class));
-        
-        JsonArray editorColumnsJson = editor.get("columns").getAsJsonArray();
-        var editorColumns = new ArrayList<CardAttribute>(editorColumnsJson.size());
-        for (var column : editorColumnsJson)
-            editorColumns.add(context.deserialize(column, CardAttribute.class));
+        if (obj.has("editor"))
+        {
+            JsonObject editor = obj.get("editor").getAsJsonObject();
 
-        JsonArray backFaceLandsJson = editor.get("backFaceLands").getAsJsonArray();
-        var backFaceLands = new HashSet<CardLayout>(backFaceLandsJson.size());
-        for (var layout : backFaceLandsJson)
-            backFaceLands.add(Arrays.stream(CardLayout.values()).filter((l) -> l.toString().equals(layout.getAsString())).findAny().get());
+            if (editor.has("recents"))
+            {
+                JsonObject recents = editor.get("recents").getAsJsonObject();
 
-        return new SettingsBuilder()
-            .defaults()
-            .inventorySource(inventory.get("source").getAsString())
-            .inventoryFile(inventory.get("file").getAsString())
-            .inventoryVersionFile(inventory.get("versionFile").getAsString())
-            .inventoryVersion(context.deserialize(inventory.get("version"), DatabaseVersion.class))
-            .inventoryLocation(inventory.get("location").getAsString())
-            .inventoryScans(inventory.get("scans").getAsString())
-            .imageSource(inventory.get("imageSource").getAsString())
-            .imageLimitEnable(inventory.get("imageLimitEnable").getAsBoolean())
-            .imageLimit(inventory.get("imageLimit").getAsInt())
-            .inventoryTags(inventory.get("tags").getAsString())
-            .inventoryUpdate(context.deserialize(inventory.get("update"), UpdateFrequency.class))
-            .inventoryColumns(inventoryColumns)
-            .inventoryBackground(context.deserialize(inventory.get("background"), Color.class))
-            .inventoryStripe(context.deserialize(inventory.get("stripe"), Color.class))
-            .inventoryWarn(inventory.get("warn").getAsBoolean())
-            .recentsCount(recents.get("count").getAsInt())
-            .recentsFiles(recentsFiles)
-            .presetCategories(presets)
-            .categoryRows(categories.get("rows").getAsInt())
-            .explicits(categories.get("explicits").getAsInt())
-            .editorColumns(editorColumns)
-            .editorStripe(context.deserialize(editor.get("stripe"), Color.class))
-            .handSize(hand.get("size").getAsInt())
-            .handRounding(hand.get("rounding").getAsString())
-            .handBackground(context.deserialize(hand.get("background"), Color.class))
-            .searchForCommander(legality.get("searchForCommander").getAsBoolean())
-            .commanderInMain(legality.get("main").getAsBoolean())
-            .commanderInAll(legality.get("all").getAsBoolean())
-            .commanderInList(legality.get("list").getAsString())
-            .sideboardName(legality.get("sideboard").getAsString())
-            .manaValue(editor.get("manaValue").getAsString())
-            .backFaceLands(backFaceLands)
-            .cwd(obj.get("cwd").getAsString())
-            .build();
+                if (recents.has("count"))
+                    builder = builder.recentsCount(recents.get("count").getAsInt());
+                if (recents.has("files"))
+                {
+                    JsonArray recentsJson = recents.get("files").getAsJsonArray();
+                    var recentsFiles = new ArrayList<String>(recentsJson.size());
+                    for (var file : recentsJson)
+                        recentsFiles.add(file.getAsString());
+                    builder = builder.recentsFiles(recentsFiles);
+                }
+            }
+
+            if (editor.has("categories"))
+            {
+                JsonObject categories = editor.get("categories").getAsJsonObject();
+
+                if (categories.has("presets"))
+                {
+                    JsonArray presetsJson = categories.get("presets").getAsJsonArray();
+                    var presets = new ArrayList<CategorySpec>(presetsJson.size());
+                    for (var preset : presetsJson)
+                        presets.add(context.deserialize(preset, CategorySpec.class));
+                    builder = builder.presetCategories(presets);
+                }
+                if (categories.has("rows"))
+                    builder = builder.categoryRows(categories.get("rows").getAsInt());
+                if (categories.has("explicits"))
+                    builder = builder.explicits(categories.get("explicits").getAsInt());
+            }
+
+            if (editor.has("hand"))
+            {
+                JsonObject hand = editor.get("hand").getAsJsonObject();
+
+                if (hand.has("size"))
+                    builder = builder.handSize(hand.get("size").getAsInt());
+                if (hand.has("rounding"))
+                    builder = builder.handRounding(hand.get("rounding").getAsString());
+                if (hand.has("background"))
+                    builder = builder.handBackground(context.deserialize(hand.get("background"), Color.class));
+            }
+
+            if (editor.has("legality"))
+            {
+                JsonObject legality = editor.get("legality").getAsJsonObject();
+
+                if (legality.has("searchForCommander"))
+                    builder = builder.searchForCommander(legality.get("searchForCommander").getAsBoolean());
+                if (legality.has("main"))
+                    builder = builder.commanderInMain(legality.get("main").getAsBoolean());
+                if (legality.has("all"))
+                    builder = builder.commanderInAll(legality.get("all").getAsBoolean());
+                if (legality.has("list"))
+                    builder = builder.commanderInList(legality.get("list").getAsString());
+                if (legality.has("sideboard"))
+                    builder = builder.sideboardName(legality.get("sideboard").getAsString());
+            }
+
+            if (editor.has("columns"))
+            {
+                JsonArray editorColumnsJson = editor.get("columns").getAsJsonArray();
+                var editorColumns = new ArrayList<CardAttribute>(editorColumnsJson.size());
+                for (var column : editorColumnsJson)
+                    editorColumns.add(context.deserialize(column, CardAttribute.class));
+                builder = builder.editorColumns(editorColumns);
+            }
+            if (editor.has("stripe"))
+                builder = builder.editorStripe(context.deserialize(editor.get("stripe"), Color.class));
+            if (editor.has("manaValue"))
+                builder = builder.manaValue(editor.get("manaValue").getAsString());
+            if (editor.has("backFaceLands"))
+            {
+                JsonArray backFaceLandsJson = editor.get("backFaceLands").getAsJsonArray();
+                var backFaceLands = new HashSet<CardLayout>(backFaceLandsJson.size());
+                for (var layout : backFaceLandsJson)
+                    backFaceLands.add(Arrays.stream(CardLayout.values()).filter((l) -> l.toString().equals(layout.getAsString())).findAny().get());
+                builder = builder.backFaceLands(backFaceLands);
+            }
+        }
+
+        if (obj.has("cwd"))
+            builder = builder.cwd(obj.get("cwd").getAsString());
+
+        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
Add a setting so the user can specify which multi-faced card layouts count as lands if they are lands on the back, but not the front.  All cards are counted as lands if their front faces are lands regardless of layout or setting.