### PR TITLE
Text Filter Regex Fix

### DIFF
--- a/src/main/scala/editor/filter/leaf/TextFilter.scala
+++ b/src/main/scala/editor/filter/leaf/TextFilter.scala
@@ -90,7 +90,7 @@ object TextFilter {
 final case class TextFilter(attribute: CardAttribute[Seq[String], TextFilter], value: (Card) => Seq[String], faces: FaceSearchOptions = FaceSearchOptions.ANY, contain: Containment = Containment.AnyOf, regex: Boolean = false, text: String = "") extends FilterLeaf {
   import TextFilter._
 
-  private def matches(s: String) = if (regex) s"(?si)${replaceTokens(text)}".r.findFirstIn(s).isDefined else contain match {
+  def matches(s: String) = if (regex) s"(?si)${replaceTokens(text)}".r.findFirstIn(s).isDefined else contain match {
     case AllOf => createSimpleMatcher(text)(s)
     case AnyOf | NoneOf =>
       val r = WordPattern.findAllMatchIn(text).map((m) => {


### PR DESCRIPTION
Fix exception that occurs when `\Q` or `\E` (and possibly other regex tokens) is entered into a `TextFilter` field that's set to "contains any of" or "contains none of".